### PR TITLE
Fix `carbon.identity.framwork` dependency issue in 5.11 IS

### DIFF
--- a/components/org.wso2.carbon.identity.conditional.auth.config.entgra/pom.xml
+++ b/components/org.wso2.carbon.identity.conditional.auth.config.entgra/pom.xml
@@ -18,7 +18,8 @@
   ~ under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.wso2.carbon.identity.conditional.auth.entgra</groupId>
         <artifactId>identity-conditional-auth-entgra</artifactId>
@@ -110,10 +111,13 @@
                             org.apache.commons.lang;version="${apache.commons.lang.imp.pkg.version}",
                             org.apache.commons.logging;version="${apache.commons.logging.imp.pkg.version}",
                             org.osgi.service.component;version="${osgi.service.component.imp.pkg.version.range}",
-                            org.osgi.service.component.annotations;version="${osgi.service.component.imp.pkg.version.range}",
+                            org.osgi.service.component.annotations;
+                            version="${osgi.service.component.imp.pkg.version.range}",
                             org.osgi.framework;version="${osgi.framework.imp.pkg.version.range}",
-                            org.wso2.carbon.identity.application.authentication.framework;version="${carbon.identity.framework.version}",
-                            org.wso2.carbon.identity.application.authentication.framework.context;version="${carbon.identity.framework.version}",
+                            org.wso2.carbon.identity.application.authentication.framework;
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.application.authentication.framework.context;
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.governance,
                             org.wso2.carbon.identity.governance.common,
                             org.wso2.carbon.registry.core.service,

--- a/components/org.wso2.carbon.identity.conditional.auth.functions.entgra/pom.xml
+++ b/components/org.wso2.carbon.identity.conditional.auth.functions.entgra/pom.xml
@@ -18,7 +18,8 @@
   ~ under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.wso2.carbon.identity.conditional.auth.entgra</groupId>
         <artifactId>identity-conditional-auth-entgra</artifactId>
@@ -100,27 +101,28 @@
                             org.json.simple,
                             org.json.simple.parser,
                             org.osgi.service.component;version="${osgi.service.component.imp.pkg.version.range}",
-                            org.osgi.service.component.annotations;version="${osgi.service.component.imp.pkg.version.range}",
+                            org.osgi.service.component.annotations;
+                            version="${osgi.service.component.imp.pkg.version.range}",
                             org.osgi.framework;version="${osgi.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework;
-                            version="${carbon.identity.framework.version}",
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework.util;
-                            version="${carbon.identity.framework.version}",
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework.exception;
-                            version="${carbon.identity.framework.version}",
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework.model;
-                            version="${carbon.identity.framework.version}",
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework.config.model.graph.js;
-                            version="${carbon.identity.framework.version}",
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework.config.model.graph;
-                            version="${carbon.identity.framework.version}",
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework.config.model;
-                            version="${carbon.identity.framework.version}",
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework.context;
-                            version="${carbon.identity.framework.version}",
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.conditional.auth.functions.common.*,
                             org.wso2.carbon.identity.event;
-                            version="${carbon.identity.framework.version}",
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
                         </Import-Package>
                     </instructions>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,8 @@
   ~ under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -166,6 +167,8 @@
         <carbon.kernel.package.import.version.range>[4.5.1, 5.0.0)</carbon.kernel.package.import.version.range>
         <imp.pkg.version.javax.servlet>[2.5.0, 3.0.0)</imp.pkg.version.javax.servlet>
         <carbon.identity.framework.version>5.20.189</carbon.identity.framework.version>
+        <carbon.identity.framework.imp.pkg.version.range>[5.14.97, 6.0.0)
+        </carbon.identity.framework.imp.pkg.version.range>
         <osgi.framework.imp.pkg.version.range>[1.7.0, 2.0.0)</osgi.framework.imp.pkg.version.range>
         <osgi.service.component.imp.pkg.version.range>[1.2.0, 2.0.0)</osgi.service.component.imp.pkg.version.range>
         <carbon.identity.conditional.auth.functions.imp.pkg.version.range>[1.1.6, 2.0.0)


### PR DESCRIPTION
## Purpose
>Current implementation had dependency issue with IS 5.11 versions. This PR fixes that issue by adding `carbon.identity.framwork.imp.pkg.version.range`.